### PR TITLE
Updates to SX1280 LoRa radio driver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
         "*.bc": "ini",
-        "fcbbadc.h": "c"
+        "fcbbadc.h": "c",
+        "stm32h7xx_hal.h": "c"
     }
 }

--- a/board-drivers/SX1280/inc/SX1280.h
+++ b/board-drivers/SX1280/inc/SX1280.h
@@ -51,8 +51,8 @@
 
 // PeriodBase definitions for SetTx/SetRx timeout (Table 11-24)
 // These define the time step used for timeout calculations
-#define SX1280_PERIODBASE_15_625_US  0x00  // 15.625 μs steps
-#define SX1280_PERIODBASE_62_5_US    0x01  // 62.5 μs steps
+#define SX1280_PERIODBASE_15_625_US  0x00  // 15.625 us steps
+#define SX1280_PERIODBASE_62_5_US    0x01  // 62.5 us steps
 #define SX1280_PERIODBASE_1_MS       0x02  // 1 ms steps
 #define SX1280_PERIODBASE_4_MS       0x03  // 4 ms steps
 
@@ -202,7 +202,7 @@ int16_t SX1280_ReadBuffer(uint8_t* data, uint8_t maxLength);
 // config prototypes
 /**
 * @brief set radio packet type (ex. LORA, GFSK).
-* Really we are only using LORA(?)
+* LoRa is recommended for long-range telemetry applications
 */
 SX1280_Status_t SX1280_SetPacketType(SX1280_PacketType_t packetType);
 

--- a/board-drivers/SX1280/inc/SX1280.h
+++ b/board-drivers/SX1280/inc/SX1280.h
@@ -61,7 +61,7 @@
 #define SX1280_RX_TIMEOUT_NONE       0x0000  // No timeout, Rx single mode
 #define SX1280_RX_TIMEOUT_CONTINUOUS 0xFFFF  // Continuous RX mode
 
-
+#define SX1280_SPI_TIMEOUT_MS 100
 
 
 
@@ -250,6 +250,20 @@ SX1280_Status_t SX1280_SetBufferBaseAddress(uint8_t txBaseAddress, uint8_t rxBas
 SX1280_Status_t SX1280_SetTxParams(int8_t power, uint8_t rampTime);
 
 
+/**
+* @brief Enables the High Sensitivity Mode (LNA boost).
+*
+* noted in datasheet section 4.2.1, this enables the lowest noise,
+* highest sensitivity gain steps for up to 3dB sensitivity improvement,
+* at the cost of around 500uA of additional current consumption.
+*
+* This function performs a Read-Modify-Write on register 0x0891.
+*
+* @return SX1280_Status_t Status of operation
+*/
+SX1280_Status_t SX1280_SetHighSensitivityMode(void);
+
+
 
 /**
 * @brief Put radio in TX mode to transmit packet
@@ -285,11 +299,9 @@ SX1280_Status_t SX1280_SetRx(uint16_t timeout);
 * @param buffer pointer to command arguments
 * @param size number of param bytes
 */
-void SX1280_SendCommand(uint8_t opcode, uint8_t* buffer, uint16_t size);
-
-
-void SX1280_WriteRegister(uint16_t address, uint8_t* buffer, uint16_t size);
-void SX1280_ReadRegister(uint16_t address, uint8_t* buffer, uint16_t size);
+SX1280_Status_t SX1280_SendCommand(uint8_t opcode, uint8_t* buffer, uint16_t size);
+SX1280_Status_t SX1280_WriteRegister(uint16_t address, uint8_t* buffer, uint16_t size);
+SX1280_Status_t SX1280_ReadRegister(uint16_t address, uint8_t* buffer, uint16_t size);
 
 
 

--- a/board-drivers/SX1280/inc/SX1280.h
+++ b/board-drivers/SX1280/inc/SX1280.h
@@ -227,7 +227,19 @@ void SX1280_Status_t SX1280_SetTxParams(int8_t power, uint8_t rampTime);
 
 
 
+/**
+* @brief Put radio in TX mode to transmit packet
+* @param timeout timeout in milliseconds (0 = no timeout)
+* @return SX1280_Status_t status of operation
+*/
+SX1280_Status_t SX1280_SetTx(uint16_t timeout);
 
+/**
+* @brief Put radio in RX mode to receive packets
+* @param timeout timeout in milliseconds (0 = continuous)
+* @return SX1280_Status_t status of operation
+*/
+SX1280_Status_t SX1280_SetRx(uint16_t timeout);
 
 
 

--- a/board-drivers/SX1280/inc/SX1280.h
+++ b/board-drivers/SX1280/inc/SX1280.h
@@ -39,6 +39,32 @@
 #define SX1280_CMD_SET_BUFFER_BASE_ADDRESS 0x8F
 #define SX1280_CMD_GET_RX_BUFFER_STATUS 0x17
 
+// Ramp time definitions for SetTxParams (Table 11-49)
+#define SX1280_RAMP_02_US  0x00  // 2 us
+#define SX1280_RAMP_04_US  0x20  // 4 us
+#define SX1280_RAMP_06_US  0x40  // 6 us
+#define SX1280_RAMP_08_US  0x60  // 8 us
+#define SX1280_RAMP_10_US  0x80  // 10 us
+#define SX1280_RAMP_12_US  0xA0  // 12 us
+#define SX1280_RAMP_16_US  0xC0  // 16 us
+#define SX1280_RAMP_20_US  0xE0  // 20 us
+
+// PeriodBase definitions for SetTx/SetRx timeout (Table 11-24)
+// These define the time step used for timeout calculations
+#define SX1280_PERIODBASE_15_625_US  0x00  // 15.625 μs steps
+#define SX1280_PERIODBASE_62_5_US    0x01  // 62.5 μs steps
+#define SX1280_PERIODBASE_1_MS       0x02  // 1 ms steps
+#define SX1280_PERIODBASE_4_MS       0x03  // 4 ms steps
+
+// Special timeout values for SetTx/SetRx
+#define SX1280_TX_TIMEOUT_NONE       0x0000  // No timeout, Tx single mode
+#define SX1280_RX_TIMEOUT_NONE       0x0000  // No timeout, Rx single mode
+#define SX1280_RX_TIMEOUT_CONTINUOUS 0xFFFF  // Continuous RX mode
+
+
+
+
+
 
 /**
 * @brief status enum for driver functions
@@ -65,8 +91,6 @@ typedef struct {
    uint16_t resetPin;
    GPIO_TypeDef* busyPort;
    uint16_t busyPin;
-   GPIO_TypeDef* irq_port; // DIO1 pin
-   uint16_t irq_pin;
 } SX1280_Hal_t;
 
 
@@ -229,15 +253,20 @@ SX1280_Status_t SX1280_SetTxParams(int8_t power, uint8_t rampTime);
 
 /**
 * @brief Put radio in TX mode to transmit packet
-* @param timeout timeout in milliseconds (0 = no timeout)
-* @return SX1280_Status_t status of operation
+* @param timeout Timeout in milliseconds (uses 1ms steps)
+*                0 = no timeout (single mode, returns to STDBY_RC after packet sent)
+*                >0 = timeout active (returns to STDBY_RC on timeout or after packet sent)
+* @return SX1280_Status_t Status of operation
 */
 SX1280_Status_t SX1280_SetTx(uint16_t timeout);
 
 /**
 * @brief Put radio in RX mode to receive packets
-* @param timeout timeout in milliseconds (0 = continuous)
-* @return SX1280_Status_t status of operation
+* @param timeout Timeout in milliseconds (uses 1ms steps)
+*                0x0000 = no timeout (single mode, returns to STDBY_RC after packet received)
+*                0xFFFF = continuous mode (stays in RX, can receive multiple packets)
+*                other = timeout active (returns to STDBY_RC on timeout or after packet received)
+* @return SX1280_Status_t Status of operation
 */
 SX1280_Status_t SX1280_SetRx(uint16_t timeout);
 

--- a/board-drivers/SX1280/inc/SX1280.h
+++ b/board-drivers/SX1280/inc/SX1280.h
@@ -180,14 +180,14 @@ int16_t SX1280_ReadBuffer(uint8_t* data, uint8_t maxLength);
 * @brief set radio packet type (ex. LORA, GFSK).
 * Really we are only using LORA(?)
 */
-void SX1280_Status_t SX1280_SetPacketType(SX1280_PacketType_t packetType);
+SX1280_Status_t SX1280_SetPacketType(SX1280_PacketType_t packetType);
 
 
 /**
 * @brief set radio carrier freq
 * @param frequency the frequency in Hz (ex. 2400000000 for 2.4 GHz)
 */
-void SX1280_Status_t SX1280_SetRfFrequency(uint32_t frequency);
+SX1280_Status_t SX1280_SetRfFrequency(uint32_t frequency);
 
 
 /**
@@ -196,7 +196,7 @@ void SX1280_Status_t SX1280_SetRfFrequency(uint32_t frequency);
 * @param bw bandwidth (LoRa only)
 * @param cr coding rate (LoRa only)
 */
-void SX1280_Status_t SX1280_SetModulationParams(SX1280_LoRa_SF_t sf, SX1280_LoRa_BW_t bw, SX1280_LoRa_CR_t cr);
+SX1280_Status_t SX1280_SetModulationParams(SX1280_LoRa_SF_t sf, SX1280_LoRa_BW_t bw, SX1280_LoRa_CR_t cr);
 
 
 /**
@@ -207,7 +207,7 @@ void SX1280_Status_t SX1280_SetModulationParams(SX1280_LoRa_SF_t sf, SX1280_LoRa
 * @param crcOn crc on or off (LoRa only)
 * @param invertIQ standard or inverted IQ (LoRa only)
 */
-void SX1280_Status_t SX1280_SetPacketParams(uint16_t preambleLength, SX1280_LoRa_Header_Type_t headerType, uint8_t payloadLength, SX1280_LoRa_CRC_t crc, SX1280_LoRa_IQ_t invertIQ);
+SX1280_Status_t SX1280_SetPacketParams(uint16_t preambleLength, SX1280_LoRa_Header_Type_t headerType, uint8_t payloadLength, SX1280_LoRa_CRC_t crc, SX1280_LoRa_IQ_t invertIQ);
 
 
 /**
@@ -215,7 +215,7 @@ void SX1280_Status_t SX1280_SetPacketParams(uint16_t preambleLength, SX1280_LoRa
 * @param txBaseAddress start address for the TX buffer (0-255)
 * @param rxBaseAddress start address for the RX buffer (0-255)
 */
-void SX1280_Status_t SX1280_SetBufferBaseAddress(uint8_t txBaseAddress, uint8_t rxBaseAddress);
+SX1280_Status_t SX1280_SetBufferBaseAddress(uint8_t txBaseAddress, uint8_t rxBaseAddress);
 
 
 /**
@@ -223,7 +223,7 @@ void SX1280_Status_t SX1280_SetBufferBaseAddress(uint8_t txBaseAddress, uint8_t 
 * @param power output power in dBm (-18 to +13 dBm)
 * @param rampTime Ramp time constant.
 */
-void SX1280_Status_t SX1280_SetTxParams(int8_t power, uint8_t rampTime);
+SX1280_Status_t SX1280_SetTxParams(int8_t power, uint8_t rampTime);
 
 
 

--- a/board-drivers/SX1280/inc/SX1280.h
+++ b/board-drivers/SX1280/inc/SX1280.h
@@ -246,6 +246,8 @@ SX1280_Status_t SX1280_SetRx(uint16_t timeout);
 
 
 
+
+
 // low level API prototypes --------------------//
 /**
 * @brief sends a command to sx1280

--- a/board-drivers/SX1280/src/SX1280.c
+++ b/board-drivers/SX1280/src/SX1280.c
@@ -31,6 +31,9 @@
 #define STDBY_RC 0x00
 #define STDBY_XOSC 0x01
 
+// buffer offset for write operations
+#define TX_BUFFER_OFFSET 0x00
+
 
 //***********************************************************
 // * PRIVATE VARIABLES
@@ -79,69 +82,300 @@ SX1280_Status_t SX1280_Init(SX1280_Hal_t* hal_config) {
 
 
    // default to LoRa packet type
-   SX1280_SetPacketType(PACKET_TYPE_LORA);
-   SX1280_SetRfFrequency(2400000000); //2.4 GHz
-   SX1280_SetBufferBaseAddress(0, 128);
-   SX1280_SetModulationParams(LORA_SF8, LORA_BW_400, LORA_CR_4_5);  //NOTEHERE IS WHERE TO ACHIEVE EFFECTIVE BIT RATES. REF. TABLE
-   SX1280_SetPacketParams(12, LORA_EXPLICIT_HEADER, 255, LORA_CRC_ON, LORA_IQ_STANDARD);
-   SX1280_SetTxParams(0, 0x80); //0dbm, 10us ramp time
-   return SX1280_OK;
+   // more robust handling here(?)
+   // default lora packet
+   if (SX1280_SetPacketType(PACKET_TYPE_LORA) != SX1280_OK){
+        return SX1280_ERROR;
+   }
+
+   // config default settings
+    if (SX1280_SetRfFrequency(2400000000) != SX1280_OK) { // 2.4 GHz
+        return SX1280_ERROR;
+    }
+    if (SX1280_SetBufferBaseAddress(0, 128) != SX1280_OK) {
+        return SX1280_ERROR;
+    }
+    if (SX1280_SetModulationParams(LORA_SF8, LORA_BW_400, LORA_CR_4_5) != SX1280_OK) {
+        return SX1280_ERROR;
+    }
+    if (SX1280_SetPacketParams(12, LORA_EXPLICIT_HEADER, 255, LORA_CRC_ON, LORA_IQ_STANDARD) != SX1280_OK) {
+        return SX1280_ERROR;
+    }
+    if (SX1280_SetTxParams(0, 0x80) != SX1280_OK) { // 0dBm, 10us ramp time
+        return SX1280_ERROR;
+    }
+
+    return SX1280_OK;
+
 }
 
 
 SX1280_Status_t SX1280_WriteBuffer(uint8_t *data, uint8_t length)
 {
-   uint8_
+    if (data == NULL || length == 0) {
+        return SX1280_ERROR;
+    }
+
+    // opcode + offset + data
+    uint8_t cmd_buffer[2+length];
+
+    cmd_buffer[0] = SX1280_CMD_WRITE_BUFFER;
+    cmd_buffer[1] = TX_BUFFER_OFFSET;
+
+    memcpy(&cmd_buffer[2], data, length);
+
+    // send cmd with data here
+    SX1280_SPI_TransmitReceive(cmd_buffer, NULL, 2 + length);
+
+    return SX1280_OK;
 }
+
+int16_t SX1280_ReadBuffer(uint8_t* data, uint8_t maxLength) {
+    if (data == NULL || maxLength == 0) {
+        return -1;
+    }
+    // get rx buffer status to find out where data is, how much
+    uint8_t cmd[3] = {SX1280_CMD_GET_RX_BUFFER_STATUS, SX1280_NOP, SX1280_NOP};
+    uint8_t response[3];
+    SX1280_SPI_TransmitReceive(cmd, response, 3);
+
+    // [1] should be the payload length received
+    // [2] should be the rx buffer start pointer
+    uint8_t payloadLength = response[1];
+    uint8_t rxBufferOffset = response[2];
+
+    if (payloadLength == 0)
+    {
+        return 0; // this is no data
+    }
+
+    if (payloadLength > maxLength) {
+        payloadLength = maxLength; // otherwise truncate to buffer size
+    }
+
+    // read real data from buffer
+    uint8_t read_cmd[2+payloadLength];
+    uint8_t read_response[2+payloadLength];
+
+    read_cmd[0] = SX1280_CMD_READ_BUFFER;
+    read_cmd[1] = rxBufferOffset;
+    memset(&read_cmd[2], SX1280_NOP, payloadLength);
+
+    SX1280_SPI_TransmitReceive(read_cmd, read_response, 2 + payloadLength);
+
+    // copy received data (skip 2 bytes, these are status/offset)
+    memcpy(data, &read_response[2], payloadLength);
+
+    return payloadLength;
+}
+
+SX1280_Status_t SX1280_SetPacketType(SX1280_PacketType_t packetType) {
+    uint8_t packet_type = (uint8_t)packetType;
+    SX1280_SendCommand(SX1280_CMD_SET_PACKET_TYPE, &packet_type, 1);
+    return SX1280_OK;
+}
+
+SX1280_Status_t SX12800_SetRfFrequency(uint32_t frequency) {
+    // calc frequency reg value
+    // freq = (freq * 2^18) / XTAL_FREQ
+    //bascally we are converting real frequency in Hz into a register value that SX1280's PLL knows
+    // from datasheet, section 4.3, page 31: F_RF = F_xosc / 2^18 * rfFrequency
+    // where F_RF is our desired, F_Xosc is crystal oscillator freq, rfFreq is 24-bit reg value, and
+    // 2^18 is the PLL step resolution
+    // left shift by 18 bits is the same as multiplying by 2^18
+    uint32_t freq_reg;
+    freq_reg = (uint32_t)(((uint64_t)frequency << 18) / XTAL_FREQ);
+
+    uint8_t buf[3];
+    buf[0] = (freq_reg >> 16) & 0xFF;
+    buf[1] = (freq_reg >> 8) & 0xFF;
+    buf[2] = freq_reg & 0xFF;
+
+    SX1280_SendCommand(SX1280_CMD_SET_RF_FREQUENCY, buf, 3);
+    return SX1280_OK;
+}
+
+SX1280_Status_t SX1280_SetModulationParams(SX1280_LoRa_SF_t sf, SX1280_LoRa_BW_t bw, SX1280_LoRa_CR_t cr) {
+    uint8_t buf[3];
+    buf[0] = (uint8_t)sf;
+    buf[1] = (uint8_t)bw;
+    buf[2] = (uint8_t)cr;
+    
+    SX1280_SendCommand(SX1280_CMD_SET_MODULATION_PARAMS, buf, 3);
+    return SX1280_OK;
+}
+
+SX1280_Status_t SX1280_SetPacketParams(uint16_t preambleLength, 
+                                        SX1280_LoRa_Header_Type_t headerType, 
+                                        uint8_t payloadLength, 
+                                        SX1280_LoRa_CRC_t crc, 
+                                        SX1280_LoRa_IQ_t invertIQ) {
+    uint8_t buf[7];
+    buf[0] = (preambleLength >> 8) & 0xFF;  // Preamble length MSB
+    buf[1] = preambleLength & 0xFF;         // Preamble length LSB
+    buf[2] = (uint8_t)headerType;           // Header type
+    buf[3] = payloadLength;                 // Payload length
+    buf[4] = (uint8_t)crc;                  // CRC mode
+    buf[5] = (uint8_t)invertIQ;             // IQ setting
+    buf[6] = 0x00;                          // Reserved
+    
+    SX1280_SendCommand(SX1280_CMD_SET_PACKET_PARAMS, buf, 7);
+    return SX1280_OK;
+}
+
+SX1280_Status_t SX1280_SetBufferBaseAddress(uint8_t txBaseAddress, uint8_t rxBaseAddress) {
+    uint8_t buf[2];
+    buf[0] = txBaseAddress;
+    buf[1] = rxBaseAddress;
+    
+    SX1280_SendCommand(SX1280_CMD_SET_BUFFER_BASE_ADDRESS, buf, 2);
+    return SX1280_OK;
+}
+
+SX1280_Status_t SX1280_SetTxParams(int8_t power, uint8_t rampTime) {
+    uint8_t buf[2];
+    
+    // -18 to +13, so constrain power to what we want
+    if (power < -18) power = -18;
+    if (power > 13) power = 13;
+    
+    // Power is offset by +18 to convert to register value (0-31)
+    buf[0] = (uint8_t)(power + 18);
+    buf[1] = rampTime;
+    
+    SX1280_SendCommand(SX1280_CMD_SET_TX_PARAMS, buf, 2);
+    return SX1280_OK;
+}
+
+SX1280_Status_t SX1280_SetTx(uint16_t timeout) {
+    // timeout is in units of 15.625 us (see table 11-22)
+    // convert milliseconds to these units: timeout_ms * 64
+    uint8_t buf[3];
+    buf[0] = 0x00; // periodbase is 1ms step for lora
+    buf[1] = (timeout >> 8) & 0xFF;
+    buf[2] = timeout & 0xFF;
+    
+    SX1280_SendCommand(SX1280_CMD_SET_TX, buf, 3);
+    return SX1280_OK;
+}
+
+SX1280_Status_t SX1280_SetRx(uint16_t timeout) {
+    // this timeout maybe troll but it might aso just be the same as tx
+    // 0xFFFF = continuous RX mode
+    uint8_t buf[3];
+    buf[0] = 0x00; // Periodbase = 1ms steps for LoRa
+    buf[1] = (timeout >> 8) & 0xFF;
+    buf[2] = timeout & 0xFF;
+    
+    SX1280_SendCommand(SX1280_CMD_SET_RX, buf, 3);
+    return SX1280_OK;
+}
+
+//low level api func definitions
+void SX1280_SendCommand(uint8_t opcode, uint8_t* buffer, uint16_t size) {
+    // command buffer with opcode + parameters
+    uint8_t cmd_buffer[1 + size];
+    cmd_buffer[0] = opcode;
+    
+    if (buffer != NULL && size > 0) {
+        memcpy(&cmd_buffer[1], buffer, size);
+    }
+    
+    // Send via SPI
+    SX1280_SPI_TransmitReceive(cmd_buffer, NULL, 1 + size);
+}
+
+void SX1280_WriteRegister(uint16_t address, uint8_t* buffer, uint16_t size) {
+    // command is opcode + address (16-bit) + data
+    uint8_t cmd_buffer[3 + size];
+    cmd_buffer[0] = SX1280_CMD_WRITE_REGISTER;
+    cmd_buffer[1] = (address >> 8) & 0xFF;  // Address MSB
+    cmd_buffer[2] = address & 0xFF;         // Address LSB
+    
+    if (buffer != NULL && size > 0) {
+        memcpy(&cmd_buffer[3], buffer, size);
+    }
+    
+    SX1280_SPI_TransmitReceive(cmd_buffer, NULL, 3 + size);
+}
+
+void SX1280_ReadRegister(uint16_t address, uint8_t* buffer, uint16_t size) {
+    //  opcode + address (16-bit) + NOP + data
+    uint8_t cmd_buffer[4 + size];
+    uint8_t rx_buffer[4 + size];
+    
+    cmd_buffer[0] = SX1280_CMD_READ_REGISTER;
+    cmd_buffer[1] = (address >> 8) & 0xFF;  // Address MSB
+    cmd_buffer[2] = address & 0xFF;         // Address LSB
+    cmd_buffer[3] = SX1280_NOP;             // NOP byte
+    
+    // Fill rest with NOP for reading
+    memset(&cmd_buffer[4], SX1280_NOP, size);
+    
+    SX1280_SPI_TransmitReceive(cmd_buffer, rx_buffer, 4 + size);
+    
+    // Copy received data (skip first 4 bytes)
+    if (buffer != NULL && size > 0) {
+        memcpy(buffer, &rx_buffer[4], size);
+    }
+}
+
+
+
+
+
+
 
 
    // private function definitions -------------------//
 
 
-   static void SX1280_SPI_TransmitReceive(uint8_t *pTxData, uint8_t *pRxData, uint16_t size)
-   {
-       // wait for radio to not be busy before starting SPI transaction
-       SX1280_WaitForReady(100); // 100ms timeout
+static void SX1280_SPI_TransmitReceive(uint8_t *pTxData, uint8_t *pRxData, uint16_t size)
+{
+    // wait for radio to not be busy before starting SPI transaction
+    SX1280_WaitForReady(100); // 100ms timeout
 
 
-       // enter critical section for thread safety
-       taskENTER_CRITICAL();
+    // enter critical section for thread safety
+    taskENTER_CRITICAL();
 
 
-       // set NSS low to select the radio
-       HAL_GPIO_WritePin(sx1280_hal_config->nssPort, sx1280_hal_config->nssPin, GPIO_PIN_RESET);
+    // set NSS low to select the radio
+    HAL_GPIO_WritePin(sx1280_hal_config->nssPort, sx1280_hal_config->nssPin, GPIO_PIN_RESET);
 
 
-       // perform SPI transaction
-       if (pRxData == NULL)
-       {
-           HAL_SPI_Transmit(sx1280_hal_config->spiHandle, pTxData, size, HAL_MAX_DELAY);
-       }
-       else
-       {
-           HAL_SPI_TransmitReceive(sx1280_hal_config->spiHandle, pTxData, pRxData, size, HAL_MAX_DELAY);
-       }
-       // set NSS high to deselect the radio
-       HAL_GPIO_WritePin(sx1280_hal_config->nssPort, sx1280_hal_config->nssPin, GPIO_PIN_SET);
-       // exit critical section
-       taskEXIT_CRITICAL();
+    // perform SPI transaction
+    if (pRxData == NULL)
+    {
+        HAL_SPI_Transmit(sx1280_hal_config->spiHandle, pTxData, size, HAL_MAX_DELAY);
+    }
+    else
+    {
+        HAL_SPI_TransmitReceive(sx1280_hal_config->spiHandle, pTxData, pRxData, size, HAL_MAX_DELAY);
+    }
+    // set NSS high to deselect the radio
+    HAL_GPIO_WritePin(sx1280_hal_config->nssPort, sx1280_hal_config->nssPin, GPIO_PIN_SET);
+    // exit critical section
+    taskEXIT_CRITICAL();
 
 
-       // wait for radio to be ready after transaction
-       SX1280_WaitForReady(100); // 100ms timeout
-   }
+    // wait for radio to be ready after transaction
+    SX1280_WaitForReady(100); // 100ms timeout
+}
 
 
-   static SX1280_Status_t SX1280_WaitForReady(uint32_t timeout)
-   {
-       uint32_t startTick = xTaskGetTickCount();
-       while (HAL_GPIO_ReadPin(sx1280_hal_config->busyPort, sx1280_hal_config->busyPin) == GPIO_PIN_SET)
-       {
-           if ((xTaskGetTickCount() - startTick) > timeout)
-           {
-               return SX1280_TIMEOUT;
-           }
-       }
-       return SX1280_OK;
-   }
+static SX1280_Status_t SX1280_WaitForReady(uint32_t timeout)
+{
+    uint32_t startTick = xTaskGetTickCount();
+    while (HAL_GPIO_ReadPin(sx1280_hal_config->busyPort, sx1280_hal_config->busyPin) == GPIO_PIN_SET)
+    {
+        if ((xTaskGetTickCount() - startTick) > timeout)
+        {
+            return SX1280_TIMEOUT;
+        }
+        //delay?
+        vTaskDelay(1);
+    }
+    return SX1280_OK;
+}
 

--- a/board-drivers/SX1280/src/SX1280.c
+++ b/board-drivers/SX1280/src/SX1280.c
@@ -82,7 +82,7 @@ SX1280_Status_t SX1280_Init(SX1280_Hal_t* hal_config) {
    SX1280_SetPacketType(PACKET_TYPE_LORA);
    SX1280_SetRfFrequency(2400000000); //2.4 GHz
    SX1280_SetBufferBaseAddress(0, 128);
-   SX1280_SetModulationParams(LORA_SF7, LORA_BW_1600, LORA_CR_4_5);
+   SX1280_SetModulationParams(LORA_SF8, LORA_BW_400, LORA_CR_4_5);  //NOTEHERE IS WHERE TO ACHIEVE EFFECTIVE BIT RATES. REF. TABLE
    SX1280_SetPacketParams(12, LORA_EXPLICIT_HEADER, 255, LORA_CRC_ON, LORA_IQ_STANDARD);
    SX1280_SetTxParams(0, 0x80); //0dbm, 10us ramp time
    return SX1280_OK;

--- a/board-drivers/SX1280/src/SX1280.c
+++ b/board-drivers/SX1280/src/SX1280.c
@@ -71,9 +71,9 @@ SX1280_Status_t SX1280_Init(SX1280_Hal_t* hal_config) {
 
    // perform hardware reset
    HAL_GPIO_WritePin(sx1280_hal_config->resetPort, sx1280_hal_config->resetPin, GPIO_PIN_RESET);
-   HAL_Delay(20); //reset pulse
+   vTaskDelay(20); //reset pulse
    HAL_GPIO_WritePin(sx1280_hal_config->resetPort, sx1280_hal_config->resetPin, GPIO_PIN_SET);
-   HAL_Delay(50); //wait for chip to boot
+   vTaskDelay(50); //wait for chip to boot
 
 
    //set radio to state STDBY_RC

--- a/board-drivers/SX1280/src/SX1280.c
+++ b/board-drivers/SX1280/src/SX1280.c
@@ -73,7 +73,7 @@ SX1280_Status_t SX1280_Init(SX1280_Hal_t* hal_config) {
    HAL_GPIO_WritePin(sx1280_hal_config->resetPort, sx1280_hal_config->resetPin, GPIO_PIN_RESET);
    HAL_Delay(20); //reset pulse
    HAL_GPIO_WritePin(sx1280_hal_config->resetPort, sx1280_hal_config->resetPin, GPIO_PIN_SET);
-   HAL_DELAY(50); //wait for chip to boot
+   HAL_Delay(50); //wait for chip to boot
 
 
    //set radio to state STDBY_RC
@@ -175,7 +175,7 @@ SX1280_Status_t SX1280_SetPacketType(SX1280_PacketType_t packetType) {
     return SX1280_OK;
 }
 
-SX1280_Status_t SX12800_SetRfFrequency(uint32_t frequency) {
+SX1280_Status_t SX1280_SetRfFrequency(uint32_t frequency) {
     // calc frequency reg value
     // freq = (freq * 2^18) / XTAL_FREQ
     //bascally we are converting real frequency in Hz into a register value that SX1280's PLL knows

--- a/board-drivers/SX1280/src/SX1280.c
+++ b/board-drivers/SX1280/src/SX1280.c
@@ -99,7 +99,7 @@ SX1280_Status_t SX1280_Init(SX1280_Hal_t* hal_config) {
     if (SX1280_SetPacketParams(12, LORA_EXPLICIT_HEADER, 255, LORA_CRC_ON, LORA_IQ_STANDARD) != SX1280_OK) {
         return SX1280_ERROR;
     }
-    if (SX1280_SetTxParams(0, SX1280_RAMP_10_US) != SX1280_OK) { // 0dBm, 10us ramp time
+    if (SX1280_SetTxParams(13, SX1280_RAMP_10_US) != SX1280_OK) { // 13dBm, 10us ramp time
         return SX1280_ERROR;
     }
 

--- a/board-drivers/SX1280/src/SX1280.c
+++ b/board-drivers/SX1280/src/SX1280.c
@@ -81,9 +81,7 @@ SX1280_Status_t SX1280_Init(SX1280_Hal_t* hal_config) {
    SX1280_SendCommand(SX1280_CMD_SET_STANDBY, &standby_mode, 1);
 
 
-   // default to LoRa packet type
    // Set default LoRa packet type
-   // default lora packet
    if (SX1280_SetPacketType(PACKET_TYPE_LORA) != SX1280_OK){
         return SX1280_ERROR;
    }
@@ -178,7 +176,7 @@ SX1280_Status_t SX1280_SetPacketType(SX1280_PacketType_t packetType) {
 SX1280_Status_t SX1280_SetRfFrequency(uint32_t frequency) {
     // calc frequency reg value
     // freq = (freq * 2^18) / XTAL_FREQ
-    //bascally we are converting real frequency in Hz into a register value that SX1280's PLL knows
+    // Converting real frequency in Hz into a register value for SX1280's PLL
     // from datasheet, section 4.3, page 31: F_RF = F_xosc / 2^18 * rfFrequency
     // where F_RF is our desired, F_Xosc is crystal oscillator freq, rfFreq is 24-bit reg value, and
     // 2^18 is the PLL step resolution


### PR DESCRIPTION
Implements SX1280 LoRa radio driver with all required functions:
- Init, Send/Receive commands, Register access, TX/RX data buffers
- Polling-based operation, thread-safe SPI communication (Removed IRQ handling as it seemed kind of redundant or pointless)
- Default config: 2.4 GHz, SF8, 400kHz BW

Ready for hardware testing.